### PR TITLE
Bump fastify-secrets-core from 2.0.0 to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">= 12.13.0"
   },
   "dependencies": {
-    "fastify-secrets-core": "^2.0.0"
+    "fastify-secrets-core": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-n": "^16.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-promise": "^6.0.0",
-    "fastify": "^4.0.3",
+    "fastify": "^5.0.0",
     "husky": "^9.0.11",
     "lint-staged": "^15.0.1",
     "prettier": "^3.0.1",


### PR DESCRIPTION
Bump fastify-secrets-core from 2.0.0 to 3.0.0 to support fastify 5.x
Closes https://github.com/nearform/fastify-secrets-env/issues/250